### PR TITLE
Add script to find tags

### DIFF
--- a/find.sh
+++ b/find.sh
@@ -1,0 +1,67 @@
+#! /bin/bash
+#
+# Copyright (c) 2025, Oracle and/or its affiliates. All rights reserved.
+
+KUBE_VERSION="$1"
+
+REGISTRY="container-registry.oracle.com/olcne"
+if [ -n "$2" ]; then
+	REGISTRY="$2"
+fi
+
+echo "Searcing $REGISTRY"
+
+imgs="kube-apiserver pause etcd coredns flannel ui ui-plugins ocne-catalog nginx"
+
+declare -A imgMap
+imgMap['pause']="pause"
+imgMap['etcd']="etcd"
+imgMap['coredns']="coredns"
+imgMap['flannel']="flannel"
+imgMap['ui']="ui_tag"
+imgMap['ui-plugins']="ui_plugins"
+imgMap['ocne-catalog']="catalog"
+imgMap['nginx']="nginx"
+
+declare -A tagMap
+
+for shortImg in $imgs; do
+	img="${REGISTRY}/${shortImg}"
+	echo "Checking $img"
+	TAGS=$(skopeo list-tags "docker://${img}" | jq -r '.Tags[]' | grep -v -e '-[a-z][a-z0-9]*')
+
+	if [ "$img" == "${REGISTRY}/kube-apiserver" ]; then
+		TAGS=$(echo "$TAGS" | grep "$KUBE_VERSION")
+	fi
+	TAGS=$(echo "$TAGS" | sort -Vr)
+
+	TAG=$(echo "$TAGS" | head -1)
+	echo "$TAG"
+	tagMap["$shortImg"]="$TAG"
+done
+
+echo "---------Replace Empty Variables------------"
+
+suffix=
+for shortImg in $imgs; do
+	TAG="${tagMap[${shortImg}]}"
+	if [ "$shortImg" == "kube-apiserver" ]; then
+		maj=$(echo "$TAG" | cut -d. -f 1 | tr -d 'v')
+		min=$(echo "$TAG" | cut -d. -f 2)
+		pat=$(echo "$TAG" | cut -d. -f 3 | grep -o '^[0-9]*')
+		suffix=$(echo "$TAG" | cut -d. -f 3 | grep -o -e '-[0-9]*$')
+		echo "String verion = \"${maj}.${min}\""
+		echo "String patch = \"${pat}\""
+		echo
+		continue
+	fi
+
+	VAR="${imgMap[${shortImg}]}"
+	echo "String ${VAR} = \"$TAG\""
+done
+
+
+if [ -n "$suffix" ]; then
+	echo "-------Replace Map Entry----------"
+	echo "    \"\${reg}/kube-apiserver:v\${version}.\${patch}${suffix}\","
+fi


### PR DESCRIPTION
Finding the latest tags for images is tedious and error prone, but it can be easily scripted.  Here is such a script.

Usage
```
# Search OCR
$ sh find.sh 1.32
Searcing container-registry.oracle.com/olcne
Checking container-registry.oracle.com/olcne/kube-apiserver
v1.32.7
Checking container-registry.oracle.com/olcne/pause
3.10
Checking container-registry.oracle.com/olcne/etcd
3.5.21-1
Checking container-registry.oracle.com/olcne/coredns
v1.12.2-1
Checking container-registry.oracle.com/olcne/flannel
v0.27.1
Checking container-registry.oracle.com/olcne/ui
v2.0.0
Checking container-registry.oracle.com/olcne/ui-plugins
v2.0.0
Checking container-registry.oracle.com/olcne/ocne-catalog
v2.0.0
Checking container-registry.oracle.com/olcne/nginx
1.26.3
---------Replace Empty Variables------------
String verion = "1.32"
String patch = "7"

String pause = "3.10"
String etcd = "3.5.21-1"
String coredns = "v1.12.2-1"
String flannel = "v0.27.1"
String ui_tag = "v2.0.0"
String ui_plugins = "v2.0.0"
String catalog = "v2.0.0"
String nginx = "1.26.3"

# Search an alternate repo
$ sh find.sh 1.32 my.cool.registry
...
```