### PR TITLE
Update to Kubernetes 1.31.14

### DIFF
--- a/buildrpm/images.spec
+++ b/buildrpm/images.spec
@@ -67,5 +67,11 @@ echo "Fixing file and directory ownership"
 find /usr/ock/containers -name headlamp | xargs chown -R 100:101
 
 %changelog
-* 
-- Kubernetes 
+* Tue Oct 14 2025 Daniel Krasinski <daniel.krasinski@oracle.com> - 1.31.13-1
+- Upgrade to 1.31.13
+
+* Mon Jul 21 2025 Daniel Krasinski <daniel.krasinski@oracle.com) - 1.31.11-2
+- Upgrade to 1.31.11
+
+* Tue Jul 15 2025 Daniel Krasinski <daniel.krasinski@oracle.com) - 1.31.9-2
+- Pull in latest images

--- a/buildrpm/images.spec
+++ b/buildrpm/images.spec
@@ -67,6 +67,9 @@ echo "Fixing file and directory ownership"
 find /usr/ock/containers -name headlamp | xargs chown -R 100:101
 
 %changelog
+* Thu Dec 11 2025 Daniel Krasinski <daniel.krasinski@oracle.com> - 1.31.14-1
+- Kubernetes 1.31.14
+
 * Tue Oct 14 2025 Daniel Krasinski <daniel.krasinski@oracle.com> - 1.31.13-1
 - Upgrade to 1.31.13
 

--- a/olm/jenkins/ci/Jenkinsfile
+++ b/olm/jenkins/ci/Jenkinsfile
@@ -2,7 +2,7 @@
 import com.oracle.olcne.pipeline.BranchPattern
 
 String reg = "container-registry.oracle.com/olcne"
-String verion = "1.31"
+String version = "1.31"
 String patch = "13"
 
 String pause = "3.10"

--- a/olm/jenkins/ci/Jenkinsfile
+++ b/olm/jenkins/ci/Jenkinsfile
@@ -2,17 +2,17 @@
 import com.oracle.olcne.pipeline.BranchPattern
 
 String reg = "container-registry.oracle.com/olcne"
-String version = ""
-String patch = ""
+String verion = "1.31"
+String patch = "13"
 
-String pause = ""
-String etcd = ""
-String coredns = ""
-String flannel = ""
-String ui_tag = ""
-String ui_plugins = ""
-String catalog = ""
-String nginx = ""
+String pause = "3.10"
+String etcd = "3.5.23"
+String coredns = "v1.13.1"
+String flannel = "v0.27.3"
+String ui_tag = "v0.35.0"
+String ui_plugins = "v2.0.0"
+String catalog = "v2.0.0"
+String nginx = "1.26.3"
 String base = "container-registry.oracle.com/olcne/ock:base-image"
 
 def imgMacros = [

--- a/olm/jenkins/ci/Jenkinsfile
+++ b/olm/jenkins/ci/Jenkinsfile
@@ -3,12 +3,12 @@ import com.oracle.olcne.pipeline.BranchPattern
 
 String reg = "container-registry.oracle.com/olcne"
 String version = "1.31"
-String patch = "13"
+String patch = "14"
 
 String pause = "3.10"
-String etcd = "3.5.23"
-String coredns = "v1.13.1"
-String flannel = "v0.27.3"
+String etcd = "3.5.25"
+String coredns = "v1.13.2"
+String flannel = "v0.27.4"
 String ui_tag = "v0.35.0"
 String ui_plugins = "v2.0.0"
 String catalog = "v2.0.0"


### PR DESCRIPTION
In the time between when the issue was filed and now, 1.31.14 has become available.  So let's use that.